### PR TITLE
docs: Adds urql documentation and info about Apollo Client

### DIFF
--- a/docs/clients/apollo.md
+++ b/docs/clients/apollo.md
@@ -2,6 +2,8 @@
 title: Apollo
 ---
 
+> [Apollo Client](https://www.apollographql.com/docs/react/) is a comprehensive state management library for JavaScript that enables you to manage both local and remote data with GraphQL. Use it to fetch, cache, and modify application data, all while automatically updating your UI.
+
 `typed-graphql-builder` can easily be used with Apollo Client by substituting the `gql` function
 that comes with it. Instead of using `gql` and passing it a query string:
 

--- a/docs/clients/urql.md
+++ b/docs/clients/urql.md
@@ -1,3 +1,85 @@
 ---
 title: urql
 ---
+
+> [urql](https://formidable.com/open-source/urql/docs/) is a highly customizable and versatile GraphQL client with which you add on features like normalized caching as you grow. It's built to be both easy to use for newcomers to GraphQL, and extensible, to grow to support dynamic single-app applications and highly customized GraphQL infrastructure. In short, `urql` prioritizes usability and adaptability.
+
+`typed-graphql-builder` works with urql's bindings in addition to the core node.js architecture. Anywhere you might have used a GraphQL string or `DocumentNode` object, you can easily
+replace these with the generated objects from `typed-graphql-builder`
+
+**Before:**
+
+```ts
+const GET_TODOS = `
+  query GetTodos {
+    todos {
+      id
+      type
+    }
+  }
+`
+
+const ADD_TODO = `
+  mutation AddTodo($type: String!) {
+    addTodo(type: $type) {
+      id
+      type
+    }
+  }
+`
+```
+
+**After `typed-graphql-builder`:**
+
+```ts
+import { query, mutation } from "./generated-api"
+
+const GET_TODOS = query(q => [
+  q.todos(todo => [
+    // ...
+    todo.id,
+    todo.type,
+  ]),
+])
+
+const ADD_TODO = mutation(m => [
+  m.addTodo({ type: $("type") }, todo => [
+    // ...
+    todo.id,
+    todo.type,
+  ]),
+])
+```
+
+The type of the variable `$("type")` will be automatically inferred as `string` for us. We can then pass these query and mutation objects into urql directly:
+
+```tsx
+function ComponentWithTodos() {
+  const [{ data }] = useQuery({
+    query: GET_TODOS,
+  })
+}
+
+function AddTodo() {
+  const [todo, setTodo] = useState("")
+  const [{ fetching, error }, addTodo] = useMutation(ADD_TODO)
+
+  if (fetching) return "Submitting..."
+  if (error) return `Submission error! ${error.message}`
+
+  return (
+    <div>
+      <form
+        onSubmit={e => {
+          e.preventDefault()
+          void addTodo({ type: todo })
+          setTodo("")
+        }}
+      >
+        <input value={todo} onChange={e => setTodo(e.target.value)} />
+        <button type="submit">Add Todo</button>
+      </form>
+    </div>
+  )
+}
+```


### PR DESCRIPTION
Closes https://github.com/typed-graphql-builder/typed-graphql-builder/issues/8

* Adds urql documentation page
* Adds note about what is apollo client (with link to Apollo's docs)

Test plan:
1. Run `yarn start`
2. Access the urql and apollo pages